### PR TITLE
Remove rc-config-loader 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [ 12, 14, 16 ]
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Via `.textlintrc`(Recommended)
 - `allowlistConfigPaths`: `string[]`
     - File path list that includes allow words.
     - The File path is relative path from your `.textlintrc`.
-    - Support file format: JSON, yml, js
+    - Support file format: JSON, yml
 
 For example, you can specify `allowlistConfigPaths` to `.textlintrc`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Via `.textlintrc`(Recommended)
     - File path list that includes allow words.
     - The File path is relative path from your `.textlintrc`.
     - Support file format: JSON, yml
+    - Cannot use when using [@textlint/editor](https://github.com/textlint/editor)
 
 For example, you can specify `allowlistConfigPaths` to `.textlintrc`.
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@textlint/ast-node-types": "^12.0.0",
     "@textlint/get-config-base-dir": "^2.0.0",
-    "@textlint/regexp-string-matcher": "^1.1.0"
+    "@textlint/regexp-string-matcher": "^1.1.0",
+    "js-yaml": "^4.1.0"
   },
   "peerDependencies": {
     "textlint": ">= 9.0.0"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "@textlint/ast-node-types": "^12.0.0",
     "@textlint/get-config-base-dir": "^2.0.0",
-    "@textlint/regexp-string-matcher": "^1.1.0",
-    "rc-config-loader": "^4.0.0"
+    "@textlint/regexp-string-matcher": "^1.1.0"
   },
   "peerDependencies": {
     "textlint": ">= 9.0.0"

--- a/src/textlint-filter-rule-allowlist.js
+++ b/src/textlint-filter-rule-allowlist.js
@@ -4,17 +4,18 @@ import { getConfigBaseDir } from "@textlint/get-config-base-dir";
 import { matchPatterns } from "@textlint/regexp-string-matcher";
 
 const loadAllowlistConfigFile = (baseDirectory, filePath) => {
+    // It is for suppoting browser bundler.
     const fs = require("fs");
     const configFilePath = path.resolve(baseDirectory, filePath);
     const extName = path.extname(configFilePath);
     const configFile = fs.readFileSync(configFilePath);
     let config = null;
     if (extName == ".json") {
-        config = JSON.parse(configFile);
-    } else if (/\.(yml|yaml)/.test(extName)) {
-        config = yaml.load(configFile);
+        return JSON.parse(configFile);
+    } else if (/\.(yml|yaml)$/.test(extName)) {
+        return yaml.load(configFile);
     } else {
-        return null;
+        throw new Error(`Unsupported file type: ${filePath}`);
     }
     return config;
 };

--- a/src/textlint-filter-rule-allowlist.js
+++ b/src/textlint-filter-rule-allowlist.js
@@ -1,17 +1,30 @@
 import path from "path";
-import { rcFile } from "rc-config-loader";
+import yaml from "js-yaml";
 import { getConfigBaseDir } from "@textlint/get-config-base-dir";
 import { matchPatterns } from "@textlint/regexp-string-matcher";
+
+const loadAllowlistConfigFile = (baseDirectory, filePath) => {
+    const fs = require("fs");
+    const configFilePath = path.resolve(baseDirectory, filePath);
+    const extName = path.extname(configFilePath);
+    const configFile = fs.readFileSync(configFilePath);
+    let config = null;
+    if (extName == ".json") {
+        config = JSON.parse(configFile);
+    } else if (/\.(yml|yaml)/.test(extName)) {
+        config = yaml.load(configFile);
+    } else {
+        return null;
+    }
+    return config;
+};
 
 const getAllowWordsFromFiles = (files, baseDirectory) => {
     let results = [];
     files.forEach((filePath) => {
-        // TODO: use other loader
-        const contents = rcFile("file", {
-            configFileName: path.resolve(baseDirectory, filePath)
-        });
-        if (contents && Array.isArray(contents.config)) {
-            results = results.concat(contents.config);
+        const config = loadAllowlistConfigFile(baseDirectory, filePath);
+        if (config && Array.isArray(config)) {
+            results = results.concat(config);
         } else {
             throw new Error(`This allow file is not allow word list: ${filePath}`);
         }

--- a/src/textlint-filter-rule-allowlist.js
+++ b/src/textlint-filter-rule-allowlist.js
@@ -9,15 +9,12 @@ const loadAllowlistConfigFile = (baseDirectory, filePath) => {
     const configFilePath = path.resolve(baseDirectory, filePath);
     const extName = path.extname(configFilePath);
     const configFile = fs.readFileSync(configFilePath);
-    let config = null;
     if (extName == ".json") {
         return JSON.parse(configFile);
     } else if (/\.(yml|yaml)$/.test(extName)) {
         return yaml.load(configFile);
-    } else {
-        throw new Error(`Unsupported file type: ${filePath}`);
     }
-    return config;
+    throw new Error(`Unsupported file type: ${filePath}`);
 };
 
 const getAllowWordsFromFiles = (files, baseDirectory) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,7 +2736,7 @@ js-yaml@4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,7 +2736,7 @@ js-yaml@4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@4.1.0, js-yaml@^4.0.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -3882,16 +3882,6 @@ rc-config-loader@^3.0.0:
     debug "^4.1.1"
     js-yaml "^3.12.0"
     json5 "^2.1.1"
-    require-from-string "^2.0.2"
-
-rc-config-loader@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/rc-config-loader/-/rc-config-loader-4.0.0.tgz#144cf31961c9f8ebcf252bd9c263fd40d62bd387"
-  integrity sha512-//LRTblJEcqbmmro1GCmZ39qZXD+JqzuD8Y5/IZU3Dhp3A1Yr0Xn68ks8MQ6qKfKvYCWDveUmRDKDA40c+sCXw==
-  dependencies:
-    debug "^4.1.1"
-    js-yaml "^4.0.0"
-    json5 "^2.1.2"
     require-from-string "^2.0.2"
 
 read-pkg-up@^1.0.1:


### PR DESCRIPTION
textlint-filter-rule-allowlist cannot be used in textlint editor, because of rc-config-loader dependency.
So, I want to remove this dependency.

This pullrequest is a solution of the issue [#57 textlint\-script\-compiler cannot complie when \.textlintrc includes textlint\-filter\-rule\-allowlist config](https://github.com/textlint/editor/issues/57) of textlint/editor.

## Pros

- textlint-filter-rule-allowlist can be used in textlint/editor.
    - 	*Limits:* cannot use `allowlistConfigPaths` config in textlint/editor.

## Cons

- *Breaking:* Remove `.js` file support of `allowlistConfigPaths`

I think Pros is bigger than Cons, Because there are more places where textlint-filter-rule-allowlist is used.  

